### PR TITLE
Fix contour detection in android

### DIFF
--- a/android/src/main/java/com/reactnativefacedetection/FaceDetectionModule.java
+++ b/android/src/main/java/com/reactnativefacedetection/FaceDetectionModule.java
@@ -97,8 +97,10 @@ public class FaceDetectionModule extends ReactContextBaseJavaModule {
                         List<Map<String, Object>> faceContoursFormatted;
 
                         int classificationMode = (int) faceDetectorOptions.getDouble(KEY_CLASSIFICATION_MODE);
+                        // Get flag for the contour mode
+                        int contourMode = (int) faceDetectorOptions.getDouble(KEY_CONTOUR_MODE);
 
-                        if (classificationMode == FaceDetectorOptions.CONTOUR_MODE_NONE) {
+                        if (contourMode == FaceDetectorOptions.CONTOUR_MODE_NONE) {
                             faceContoursFormatted = new ArrayList<>(0);
                         } else {
                             faceContoursFormatted = new ArrayList<>(14);


### PR DESCRIPTION
Countour detection in android incorrectly checked "classification_mode" key. We now fix this by getting the correct "contour_mode" key, and performing contour detection based on it.