### PR TITLE
Match the output format of android package to that of typescript definitions

### DIFF
--- a/android/src/main/java/com/reactnativefacedetection/FaceDetectionUtils.java
+++ b/android/src/main/java/com/reactnativefacedetection/FaceDetectionUtils.java
@@ -54,15 +54,18 @@ public class FaceDetectionUtils {
         return faceLandmarkMap;
     }
 
-    public static float[] getPointMap(PointF point) {
-        return new float[]{point.x, point.y};
+    public static Map<String, Float> getPointMap(PointF point) {
+        Map<String, Float> newPoint= new HashMap<String, Float>();
+        newPoint.put("x", point.x);
+        newPoint.put("y", point.y);
+        return newPoint;
     }
 
     public static Map<String, Object> getContourMap(FaceContour faceContour) {
         Map<String, Object> faceContourMap = new HashMap<>();
 
         List<PointF> pointsListRaw = faceContour.getPoints();
-        List<float[]> pointsListFormatted = new ArrayList<>(pointsListRaw.size());
+        List<Map> pointsListFormatted = new ArrayList<>(pointsListRaw.size());
 
         for (PointF pointRaw : pointsListRaw) {
             pointsListFormatted.add(getPointMap(pointRaw));


### PR DESCRIPTION
The native android package output format was mismatched with the objects defined in typescript. The typescript definition expected objects, while the native module output was float list. Fixed it by replacing float list with a map.