### PR TITLE
Update FaceDetection dependency and modernize Android configs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('FaceDetection_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('FaceDetection_buildToolsVersion', '29.0.2')
+    compileSdkVersion safeExtGet('FaceDetection_compileSdkVersion', 34)
+    buildToolsVersion safeExtGet('FaceDetection_buildToolsVersion', '34.0.0')
     defaultConfig {
-        minSdkVersion safeExtGet('FaceDetection_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('FaceDetection_targetSdkVersion', 29)
+        minSdkVersion safeExtGet('FaceDetection_minSdkVersion', 26)
+        targetSdkVersion safeExtGet('FaceDetection_targetSdkVersion', 34)
         versionCode 1
         versionName "1.0"
 

--- a/react-native-face-detection.podspec
+++ b/react-native-face-detection.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
 
-  s.dependency 'GoogleMLKit/FaceDetection', '2.2.0'
+  s.dependency 'GoogleMLKit/FaceDetection', '3.2.0'
 end


### PR DESCRIPTION
This update includes important version upgrades for both the Android build configuration and the ML Kit FaceDetection dependency.

### Changes:
- Upgraded `GoogleMLKit/FaceDetection` from `2.2.0` to `3.2.0`.
- Increased Android `compileSdkVersion` and `targetSdkVersion` from 29 to 34.
- Updated `buildToolsVersion` from `29.0.2` to `34.0.0`.
- Raised `minSdkVersion` from 16 to 26 (required for compatibility with newer ML Kit versions).

### Notes:
- The updated ML Kit version may include breaking changes or improved detection accuracy.
- The increased `minSdkVersion` may drop support for older Android devices.
- Make sure to test the FaceDetection feature on target devices after upgrade.
